### PR TITLE
Feat : 댓글 무한스크롤 기능 추가, 피드상세페이지 모듈화

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-slot": "^1.2.3",
         "@tanstack/react-query": "^5.85.5",
         "@tanstack/react-query-devtools": "^5.85.5",
@@ -16,6 +17,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^12.23.12",
+        "headlessui": "^0.0.0",
         "js-cookie": "^3.0.5",
         "lucide-react": "^0.541.0",
         "next": "^14.2.0",
@@ -1961,6 +1963,44 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
+      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
+      "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.4"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -2371,6 +2411,55 @@
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
@@ -2437,6 +2526,21 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-dismissable-layer": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
@@ -2448,6 +2552,35 @@
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-callback-ref": "1.1.1",
         "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2522,6 +2655,78 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-portal": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
@@ -2577,6 +2782,37 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2695,6 +2931,48 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "license": "MIT"
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -7166,6 +7444,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/headlessui": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/headlessui/-/headlessui-0.0.0.tgz",
+      "integrity": "sha512-CHvacVPbl8AqIg2sBNKySUmumu7o15jSrCaTrIh9GW2Eq4y/krCN/vZFOsKCwlrhWQbO4267a8xvvP8bs+qREQ==",
+      "license": "MIT"
     },
     "node_modules/husky": {
       "version": "9.1.7",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-slot": "^1.2.3",
     "@tanstack/react-query": "^5.85.5",
     "@tanstack/react-query-devtools": "^5.85.5",
@@ -21,6 +22,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.23.12",
+    "headlessui": "^0.0.0",
     "js-cookie": "^3.0.5",
     "lucide-react": "^0.541.0",
     "next": "^14.2.0",

--- a/public/dropdownimg.svg
+++ b/public/dropdownimg.svg
@@ -1,0 +1,5 @@
+<svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18 19.5C18.8284 19.5 19.5 18.8284 19.5 18C19.5 17.1716 18.8284 16.5 18 16.5C17.1716 16.5 16.5 17.1716 16.5 18C16.5 18.8284 17.1716 19.5 18 19.5Z" fill="#ABB8CE" stroke="#ABB8CE" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M18 9C18.8284 9 19.5 8.32843 19.5 7.5C19.5 6.67157 18.8284 6 18 6C17.1716 6 16.5 6.67157 16.5 7.5C16.5 8.32843 17.1716 9 18 9Z" fill="#ABB8CE" stroke="#ABB8CE" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M18 30C18.8284 30 19.5 29.3284 19.5 28.5C19.5 27.6716 18.8284 27 18 27C17.1716 27 16.5 27.6716 16.5 28.5C16.5 29.3284 17.1716 30 18 30Z" fill="#ABB8CE" stroke="#ABB8CE" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/api/epigram.ts
+++ b/src/api/epigram.ts
@@ -19,6 +19,7 @@ export type Epigram = {
   content: string;
   author: string;
   tags?: { id: string; name: string }[];
+  writerId: number;
 
   likeCount: number;
   isLiked: boolean;
@@ -36,6 +37,12 @@ export async function getEpigrams(params?: { cursor?: string; limit?: number }) 
   });
   return res.data as EpigramsResponse;
 }
+
+//epigram 삭제
+export const deleteEpigram = async (id: number) => {
+  const res = await apiClient.delete(`/epigrams/${id}`);
+  return res.data;
+};
 
 //epigrams 상세조회 데이터
 export const getEpigramById = async (id: number): Promise<Epigram> => {

--- a/src/app/epigrams/[id]/EpigramDetailClient.tsx
+++ b/src/app/epigrams/[id]/EpigramDetailClient.tsx
@@ -10,7 +10,9 @@ import Likeicon from '@/assets/likeicon.svg';
 import Linkbtn from '@/assets/linkbtn.svg';
 import CommentForm from '@/components/comment/CommentForm';
 import CommentList from '@/components/comment/CommentList';
+import EpigramDropdown from '@/components/dropdown/EpigramDropdown';
 import { Button } from '@/components/ui/button';
+import { useAuth } from '@/context/AuthContext';
 
 interface Props {
   epigramId: number;
@@ -19,6 +21,7 @@ interface Props {
 export default function EpigramDetailClient({ epigramId }: Props) {
   const queryClient = useQueryClient();
   const [copied, setCopied] = useState(false);
+  const { user } = useAuth();
 
   // epigram 상세조회
   const { data: epigram, refetch: refetchEpigram } = useQuery<Epigram>({
@@ -67,13 +70,19 @@ export default function EpigramDetailClient({ epigramId }: Props) {
   return (
     <main>
       {/* 피드 */}
-      <div className='w-full bg-[repeating-linear-gradient(white,white_25px,#ABB8CE_26px)] h-[calc(100%-0px)]'>
+      <div className='w-full bg-[repeating-linear-gradient(white,white_25px,#ABB8CE_26px)] lg:bg-[repeating-linear-gradient(white,white_35px,#ABB8CE_36px)] h-[calc(100%-0px)]'>
         <div className='mx-auto pt-10 max-w-[312px] md:max-w-[384px] lg:max-w-[640px]'>
-          {epigram.tags?.map((tag) => (
-            <span key={tag.id} className='text-blue-400 text-md md:text-lg lg:text-xl mr-2'>
-              #{tag.name}
-            </span>
-          ))}
+          <div className='flex justify-between items-center'>
+            <div>
+              {epigram.tags?.map((tag) => (
+                <span key={tag.id} className='text-blue-400 text-md md:text-lg lg:text-xl mr-2'>
+                  #{tag.name}
+                </span>
+              ))}
+            </div>
+
+            {user?.id === epigram.writerId && <EpigramDropdown epigramId={epigram.id} />}
+          </div>
           <p className='font-iropke text-black-700 text-2xl lg:text-3xl font-regular mt-4 md:mt-6 lg:mt-8'>
             {epigram.content}
           </p>

--- a/src/components/comment/CommentForm.tsx
+++ b/src/components/comment/CommentForm.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useForm, SubmitHandler } from 'react-hook-form';
+
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+
+type CommentFormValues = { content: string };
+
+interface Props {
+  onSubmit: (content: string) => void;
+}
+
+export default function CommentForm({ onSubmit }: Props) {
+  const { register, handleSubmit, reset } = useForm<CommentFormValues>({
+    defaultValues: { content: '' },
+  });
+
+  const submit: SubmitHandler<CommentFormValues> = (data) => {
+    if (!data.content.trim()) return;
+    onSubmit(data.content);
+    reset();
+  };
+
+  return (
+    <form onSubmit={handleSubmit(submit)} className='w-full'>
+      <Textarea
+        placeholder='100자 이내로 입력해주세요.'
+        variant='outlined'
+        {...register('content')}
+        className='h-[66px md:h-[80px] lg:h-[104px]'
+      />
+      <div className='flex justify-end'>
+        <Button type='submit' className='lg:w-[60px] lg:h-[44px] mt-2 lg:mt-4' size='xs'>
+          저장
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/comment/CommentItem.tsx
+++ b/src/components/comment/CommentItem.tsx
@@ -1,0 +1,63 @@
+import Image from 'next/image';
+
+import { Comment } from '@/api/comment';
+import UserIcon from '@/assets/user.svg';
+import DeleteDialog from '@/components/modal/DeleteModal';
+import { useAuth } from '@/context/AuthContext';
+import { timeAgo } from '@/lib/TimeAgo';
+
+interface Props {
+  comment: Comment;
+  onDelete?: (id: number) => void;
+}
+
+export default function CommentItem({ comment, onDelete }: Props) {
+  const { user } = useAuth();
+
+  return (
+    <div>
+      <hr className='w-full' />
+      <div className='flex rounded mx-6 my-4 md:my-6 lg:my-9'>
+        {comment.writer.image ? (
+          <Image
+            src={comment.writer.image}
+            alt={`${comment.writer.nickname}의 프로필 이미지`}
+            width={24}
+            height={24}
+            className='rounded-full'
+          />
+        ) : (
+          <UserIcon className='w-6 h-6 rounded-full text-gray-300' />
+        )}
+        <div className='flex flex-col ml-4 w-full'>
+          <div className='flex justify-between items-center'>
+            <div className='flex items-center'>
+              <p className='text-xs md:text-md lg:text-lg font-regular text-black-300'>
+                {comment.writer.nickname}
+              </p>
+              <p className='text-xs md:text-md lg:text-lg font-regular text-black-300 ml-2'>
+                {timeAgo(comment.updatedAt)}
+              </p>
+            </div>
+            {user && comment.writer.id === user.id && (
+              <div className='flex gap-2'>
+                <p className='cursor-pointer text-xs md:text-md lg:text-lg font-regular text-black-600 underline'>
+                  수정
+                </p>
+                <DeleteDialog
+                  id={comment.id}
+                  description='댓글을 정말 삭제하시겠어요?'
+                  description2='삭제 후 복구할 수 없어요.'
+                  onDelete={() => onDelete?.(comment.id)}
+                />
+              </div>
+            )}
+          </div>
+          <p className='mt-2 md:mt-3 lg:mt-4 text-md md:text-lg lg:text-xl font-regular text-black-700'>
+            {comment.content}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/comment/CommentItem.tsx
+++ b/src/components/comment/CommentItem.tsx
@@ -49,6 +49,7 @@ export default function CommentItem({ comment, onDelete }: Props) {
                   description='댓글을 정말 삭제하시겠어요?'
                   description2='삭제 후 복구할 수 없어요.'
                   onDelete={() => onDelete?.(comment.id)}
+                  triggerText='삭제'
                 />
               </div>
             )}

--- a/src/components/comment/CommentList.tsx
+++ b/src/components/comment/CommentList.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useRef, useEffect } from 'react';
+
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+import { getComments, CommentsResponse, Comment } from '@/api/comment';
+import CommentItem from '@/components/comment/CommentItem';
+
+interface CommentListProps {
+  epigramId: number;
+  onDelete?: (commentId: number) => void;
+}
+
+export default function CommentList({ epigramId, onDelete }: CommentListProps) {
+  const loadMoreRef = useRef<HTMLDivElement | null>(null);
+
+  // 무한 댓글 조회
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteQuery<CommentsResponse>({
+      queryKey: ['comments', epigramId],
+      queryFn: ({ pageParam }) =>
+        getComments({ epigramId, cursor: pageParam as number | undefined, limit: 5 }),
+      getNextPageParam: (lastPage) => lastPage.nextCursor,
+      initialPageParam: undefined,
+    });
+
+  const allComments: Comment[] = data?.pages.flatMap((page) => page.list) ?? [];
+
+  // 무한 스크롤 IntersectionObserver
+  useEffect(() => {
+    if (!hasNextPage || isFetchingNextPage) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) fetchNextPage();
+      },
+      { threshold: 1.0 },
+    );
+
+    const currentRef = loadMoreRef.current;
+    if (currentRef) observer.observe(currentRef);
+
+    return () => {
+      if (currentRef) observer.unobserve(currentRef);
+    };
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  return (
+    <div className='flex flex-col mt-3 md:mt-8 lg:mt-10'>
+      {allComments.map((comment) => (
+        <CommentItem key={comment.id} comment={comment} onDelete={onDelete} />
+      ))}
+      <div ref={loadMoreRef} className='h-10 flex justify-center items-center'>
+        {isFetchingNextPage && <span>불러오는 중...</span>}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dropdown/EpigramDropdown.tsx
+++ b/src/components/dropdown/EpigramDropdown.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import React from 'react';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+
+import { deleteEpigram } from '@/api/epigram';
+import DeleteDialog from '@/components/modal/DeleteModal';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '@/components/ui/dropdown-menu';
+
+interface EpigramDropdownProps {
+  epigramId: number;
+}
+
+export default function EpigramDropdown({ epigramId }: EpigramDropdownProps) {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  //epigram 피드 삭제 mutation
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => deleteEpigram(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['epigrams'] });
+      router.push('/epigramlist');
+    },
+  });
+
+  return (
+    <DropdownMenu>
+      {/* 커스텀 이미지 버튼 */}
+      <DropdownMenuTrigger>
+        <Image src='/dropdownimg.svg' alt='옵션 버튼' width={24} height={24} />
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent className='cursor-pointer w-[97px] lg:w-[134px] rounded-xl bg-black-100 border border-blue-300 -translate-x-10 lg:-translate-x-12'>
+        {/* 수정하기 */}
+        <DropdownMenuItem className='flex justify-center font-regular text-black-600 text-md lg:text-xl '>
+          수정하기
+        </DropdownMenuItem>
+
+        {/* 삭제하기 */}
+        <DeleteDialog
+          id={epigramId}
+          description='게시글을 정말 삭제하시겠어요?'
+          description2='삭제 후 복구할 수 없습니다.'
+          onDelete={(id) => deleteMutation.mutate(id)}
+          triggerElement='삭제하기'
+        />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/modal/DeleteModal.tsx
+++ b/src/components/modal/DeleteModal.tsx
@@ -11,6 +11,7 @@ import {
   DialogFooter,
   DialogDescription,
   DialogClose,
+  DialogTitle,
 } from '@/components/ui/dialog';
 
 type DeleteDialogProps = {
@@ -19,6 +20,7 @@ type DeleteDialogProps = {
   description2: string;
   onDelete: (id: number) => void;
   triggerText?: string;
+  triggerElement?: string;
 };
 
 export default function DeleteDialog({
@@ -26,19 +28,29 @@ export default function DeleteDialog({
   description,
   description2,
   onDelete,
-  triggerText = '삭제',
+  triggerText = '삭제하기5',
+  triggerElement,
 }: DeleteDialogProps) {
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <p className='cursor-pointer text-xs md:text-md lg:text-lg font-regular text-red-500 underline'>
-          {triggerText}
-        </p>
+        {triggerElement ? (
+          <p className='cursor-pointer flex justify-center font-regular text-black-600 text-md lg:text-xl'>
+            {triggerElement}
+          </p>
+        ) : (
+          <p className='cursor-pointer text-xs md:text-md lg:text-lg font-regular text-red-500 underline'>
+            {triggerText}
+          </p>
+        )}
       </DialogTrigger>
       <DialogContent
         className='bg-white flex flex-col items-center justify-center w-[320px] md:w-[372px] lg:w-[452px] h-[238px] md:h-[282px] lg:h-[332px] px-4 md:px-[38px] py-6 md:py-8 lg:py-10 '
         showCloseButton={false}
       >
+        <DialogTitle>
+          <p className='hidden'>삭제하기</p>
+        </DialogTitle>
         <DialogHeader className='flex flex-col items-center'>
           <Image src='/warring.png' alt='경고 이미지' width={48} height={48} className='' />
           <DialogDescription className='whitespace-pre-line text-lg md:text-xl lg:text-2xl font-semibold text-black-700 mt-4 md:mt-6'>

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+import * as React from 'react';
+
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+import { CheckIcon, ChevronRightIcon, CircleIcon } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+function DropdownMenu({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot='dropdown-menu' {...props} />;
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return <DropdownMenuPrimitive.Portal data-slot='dropdown-menu-portal' {...props} />;
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return <DropdownMenuPrimitive.Trigger data-slot='dropdown-menu-trigger' {...props} />;
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot='dropdown-menu-content'
+        sideOffset={sideOffset}
+        className={cn(
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
+          className,
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  );
+}
+
+function DropdownMenuGroup({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return <DropdownMenuPrimitive.Group data-slot='dropdown-menu-group' {...props} />;
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = 'default',
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean;
+  variant?: 'default' | 'destructive';
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot='dropdown-menu-item'
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot='dropdown-menu-checkbox-item'
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className='pointer-events-none absolute left-2 flex size-3.5 items-center justify-center'>
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon className='size-4' />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  );
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return <DropdownMenuPrimitive.RadioGroup data-slot='dropdown-menu-radio-group' {...props} />;
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot='dropdown-menu-radio-item'
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <span className='pointer-events-none absolute left-2 flex size-3.5 items-center justify-center'>
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CircleIcon className='size-2 fill-current' />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  );
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot='dropdown-menu-label'
+      data-inset={inset}
+      className={cn('px-2 py-1.5 text-sm font-medium data-[inset]:pl-8', className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot='dropdown-menu-separator'
+      className={cn('bg-border -mx-1 my-1 h-px', className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<'span'>) {
+  return (
+    <span
+      data-slot='dropdown-menu-shortcut'
+      className={cn('text-muted-foreground ml-auto text-xs tracking-widest', className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSub({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot='dropdown-menu-sub' {...props} />;
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot='dropdown-menu-sub-trigger'
+      data-inset={inset}
+      className={cn(
+        'focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className='ml-auto size-4' />
+    </DropdownMenuPrimitive.SubTrigger>
+  );
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot='dropdown-menu-sub-content'
+      className={cn(
+        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) rounded-md border p-1 shadow-lg',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+};


### PR DESCRIPTION
## 🛠️ PR 유형

## 📝 요약(Summary)
- 피드 상세페이지 댓글에 무한스크롤 기능 추가
- 피드상세페이지 코드분리 모듈화
- 드롭다운 UI 추가 (shadcn)
- 피드 삭제하기 구현 (react-query)
- DeleteModal triggertext,element 조건 추가
## 📸스크린샷 (선택)

1. 무한스크롤
<img width="478" height="474" alt="image" src="https://github.com/user-attachments/assets/487e9f70-f5e0-46c6-8364-52cbaa843677" />

2. 삭제하기 드롭다운
<img width="1089" height="827" alt="image" src="https://github.com/user-attachments/assets/b9776f6b-fd52-401f-98de-ab6904344ae4" />

